### PR TITLE
Qol fixes nov4

### DIFF
--- a/pyRDDLGym_jax/core/logic.py
+++ b/pyRDDLGym_jax/core/logic.py
@@ -159,17 +159,17 @@ class YagerTNorm(TNorm):
     (x, y) -> max(1 - ((1 - x)^p + (1 - y)^p)^(1/p)).'''
     
     def __init__(self, p=2.0):
-        self.p = p
+        self.p = float(p)
     
-    def norm(self, x, y):
-        base_x = jax.nn.relu(1.0 - x)
-        base_y = jax.nn.relu(1.0 - y)
-        arg = jnp.power(base_x ** self.p + base_y ** self.p, 1.0 / self.p)
+    def norm(self, x, y):        
+        base = jax.nn.relu(1.0 - jnp.stack([x, y], axis=0))
+        arg = jnp.linalg.norm(base, ord=self.p, axis=0)
         return jax.nn.relu(1.0 - arg)
     
     def norms(self, x, axis):
-        base = jax.nn.relu(1.0 - x)
-        arg = jnp.power(jnp.sum(base ** self.p, axis=axis), 1.0 / self.p)
+        arg = jax.nn.relu(1.0 - x)
+        for ax in sorted(axis, reverse=True):
+            arg = jnp.linalg.norm(arg, ord=self.p, axis=ax)
         return jax.nn.relu(1.0 - arg)
         
 

--- a/pyRDDLGym_jax/core/logic.py
+++ b/pyRDDLGym_jax/core/logic.py
@@ -650,7 +650,7 @@ class FuzzyLogic:
         if self.verbose:
             raise_warning('Using the replacement rule: '
                           'switch(pred) { cases } --> '
-                          'sum(cases[i] * softmax(-abs(pred - i)))')   
+                          'sum(cases[i] * softmax(-(pred - i)^2))')   
             
         debias = 'switch' in self.debias
         

--- a/pyRDDLGym_jax/core/logic.py
+++ b/pyRDDLGym_jax/core/logic.py
@@ -638,7 +638,7 @@ class FuzzyLogic:
         def _jax_wrapped_calc_switch_approx(pred, cases, param):
             literals = FuzzyLogic.enumerate_literals(cases.shape, axis=0)
             pred = jnp.broadcast_to(pred[jnp.newaxis, ...], shape=cases.shape)
-            proximity = -jnp.abs(pred - literals)
+            proximity = -jnp.square(pred - literals)
             soft_case = jax.nn.softmax(param * proximity, axis=0)
             sample = jnp.sum(cases * soft_case, axis=0)
             if debias:
@@ -701,7 +701,7 @@ def _test_logical():
 def _test_indexing():
     print('testing indexing')
     _argmax, _ = logic.argmax()
-    _argmin, _ = logic.argmax()
+    _argmin, _ = logic.argmin()
 
     def argmaxmin(x):
         amax = _argmax(x, 0, w)

--- a/pyRDDLGym_jax/core/logic.py
+++ b/pyRDDLGym_jax/core/logic.py
@@ -8,28 +8,6 @@ from pyRDDLGym.core.debug.exception import raise_warning
 
 
 # ===========================================================================
-# LOGICAL COMPLEMENT
-# - abstract class
-# - standard complement
-#
-# ===========================================================================
-
-class Complement:
-    '''Base class for approximate logical complement operations.'''
-    
-    def __call__(self, x):
-        raise NotImplementedError
-
-
-class StandardComplement(Complement):
-    '''The standard approximate logical complement given by x -> 1 - x.'''
-    
-    # https://www.sciencedirect.com/science/article/abs/pii/016501149190171L
-    def __call__(self, x):
-        return 1.0 - x
-
-
-# ===========================================================================
 # RELATIONAL OPERATIONS
 # - abstract class
 # - sigmoid comparison
@@ -99,6 +77,28 @@ class SoftRounding(Rounding):
     def round(self, x, param):
         m = jnp.floor(x) + 0.5
         return m + 0.5 * jnp.tanh(param * (x - m)) / jnp.tanh(param / 2.0)    
+
+
+# ===========================================================================
+# LOGICAL COMPLEMENT
+# - abstract class
+# - standard complement
+#
+# ===========================================================================
+
+class Complement:
+    '''Base class for approximate logical complement operations.'''
+    
+    def __call__(self, x):
+        raise NotImplementedError
+
+
+class StandardComplement(Complement):
+    '''The standard approximate logical complement given by x -> 1 - x.'''
+    
+    # https://www.sciencedirect.com/science/article/abs/pii/016501149190171L
+    def __call__(self, x):
+        return 1.0 - x
 
 
 # ===========================================================================

--- a/pyRDDLGym_jax/core/planner.py
+++ b/pyRDDLGym_jax/core/planner.py
@@ -47,7 +47,6 @@ Bounds = Dict[str, Tuple[np.ndarray, np.ndarray]]
 Kwargs = Dict[str, Any]
 Pytree = Any
 
-
 # ***********************************************************************
 # CONFIG FILE MANAGEMENT
 # 
@@ -56,6 +55,7 @@ Pytree = Any
 # - instantiate planner
 #
 # ***********************************************************************
+
 
 def _parse_config_file(path: str):
     if not os.path.isfile(path):
@@ -175,7 +175,6 @@ def load_config_from_string(value: str) -> Tuple[Kwargs, ...]:
     '''Loads config file contents specified explicitly as a string value.'''
     config, args = _parse_config_string(value)
     return _load_config(config, args)
-
     
 # ***********************************************************************
 # MODEL RELAXATIONS
@@ -299,7 +298,6 @@ class JaxRDDLCompilerWithGrad(JaxRDDLCompiler):
         arg, = expr.args
         arg = self._jax(arg, info)
         return arg
-    
 
 # ***********************************************************************
 # ALL VERSIONS OF JAX PLANS
@@ -308,6 +306,7 @@ class JaxRDDLCompilerWithGrad(JaxRDDLCompiler):
 # - deep reactive policy
 #
 # ***********************************************************************
+
 
 class JaxPlan:
     '''Base class for all JAX policy representations.'''
@@ -363,7 +362,7 @@ class JaxPlan:
         self._projection = value
     
     def _calculate_action_info(self, compiled: JaxRDDLCompilerWithGrad,
-                               user_bounds: Bounds, 
+                               user_bounds: Bounds,
                                horizon: int):
         shapes, bounds, bounds_safe, cond_lists = {}, {}, {}, {}
         for (name, prange) in compiled.rddl.variable_ranges.items():
@@ -463,7 +462,7 @@ class JaxStraightLinePlan(JaxPlan):
               f'    max_projection_iters ={self._max_constraint_iter}')
     
     def compile(self, compiled: JaxRDDLCompilerWithGrad,
-                _bounds: Bounds, 
+                _bounds: Bounds,
                 horizon: int) -> None:
         rddl = compiled.rddl
         
@@ -513,14 +512,13 @@ class JaxStraightLinePlan(JaxPlan):
         def _jax_non_bool_param_to_action(var, param, hyperparams):
             if wrap_non_bool:
                 lower, upper = bounds_safe[var]
-                action = jnp.select(
-                    condlist=cond_lists[var],
-                    choicelist=[
-                        lower + (upper - lower) * jax.nn.sigmoid(param),
-                        lower + (jax.nn.elu(param) + 1.0),
-                        upper - (jax.nn.elu(-param) + 1.0),
-                        param
-                    ]
+                mb, ml, mu, mn = [mask.astype(compiled.REAL) 
+                                  for mask in cond_lists[var]]       
+                action = (
+                    mb * (lower + (upper - lower) * jax.nn.sigmoid(param)) + 
+                    ml * (lower + (jax.nn.elu(param) + 1.0)) + 
+                    mu * (upper - (jax.nn.elu(-param) + 1.0)) + 
+                    mn * param
                 )
             else:
                 action = param
@@ -780,7 +778,7 @@ class JaxDeepReactivePolicy(JaxPlan):
     def __init__(self, topology: Optional[Sequence[int]]=None,
                  activation: Activation=jnp.tanh,
                  initializer: hk.initializers.Initializer=hk.initializers.VarianceScaling(scale=2.0),
-                 normalize: bool=False, 
+                 normalize: bool=False,
                  normalize_per_layer: bool=False,
                  normalizer_kwargs: Optional[Kwargs]=None,
                  wrap_non_bool: bool=False) -> None:
@@ -828,7 +826,7 @@ class JaxDeepReactivePolicy(JaxPlan):
               f'    wrap_non_bool       ={self._wrap_non_bool}')
     
     def compile(self, compiled: JaxRDDLCompilerWithGrad,
-                _bounds: Bounds, 
+                _bounds: Bounds,
                 horizon: int) -> None:
         rddl = compiled.rddl
         
@@ -881,7 +879,7 @@ class JaxDeepReactivePolicy(JaxPlan):
                     if normalize_per_layer and value_size == 1:
                         raise_warning(
                             f'Cannot apply layer norm to state-fluent <{var}> '
-                            f'of size 1: setting normalize_per_layer = False.', 
+                            f'of size 1: setting normalize_per_layer = False.',
                             'red')
                         normalize_per_layer = False
                     non_bool_dims += value_size
@@ -906,8 +904,8 @@ class JaxDeepReactivePolicy(JaxPlan):
                     else:
                         if normalize and normalize_per_layer:
                             normalizer = hk.LayerNorm(
-                                axis=-1, param_axis=-1, 
-                                name=f'input_norm_{input_names[var]}', 
+                                axis=-1, param_axis=-1,
+                                name=f'input_norm_{input_names[var]}',
                                 **self._normalizer_kwargs)
                             state = normalizer(state)
                         states_non_bool.append(state)
@@ -917,7 +915,7 @@ class JaxDeepReactivePolicy(JaxPlan):
             # optionally perform layer normalization on the non-bool inputs
             if normalize and not normalize_per_layer and non_bool_dims:
                 normalizer = hk.LayerNorm(
-                    axis=-1, param_axis=-1, name='input_norm', 
+                    axis=-1, param_axis=-1, name='input_norm',
                     **self._normalizer_kwargs)
                 normalized = normalizer(state[:non_bool_dims])
                 state = state.at[:non_bool_dims].set(normalized)
@@ -950,14 +948,13 @@ class JaxDeepReactivePolicy(JaxPlan):
                 else:
                     if wrap_non_bool:
                         lower, upper = bounds_safe[var]
-                        action = jnp.select(
-                            condlist=cond_lists[var],
-                            choicelist=[
-                                lower + (upper - lower) * jax.nn.sigmoid(output),
-                                lower + (jax.nn.elu(output) + 1.0),
-                                upper - (jax.nn.elu(-output) + 1.0),
-                                output
-                            ]
+                        mb, ml, mu, mn = [mask.astype(compiled.REAL) 
+                                          for mask in cond_lists[var]]       
+                        action = (
+                            mb * (lower + (upper - lower) * jax.nn.sigmoid(output)) + 
+                            ml * (lower + (jax.nn.elu(output) + 1.0)) + 
+                            mu * (upper - (jax.nn.elu(-output) + 1.0)) + 
+                            mn * output
                         )
                     else:
                         action = output
@@ -1049,7 +1046,6 @@ class JaxDeepReactivePolicy(JaxPlan):
         
     def guess_next_epoch(self, params: Pytree) -> Pytree:
         return params
-
     
 # ***********************************************************************
 # ALL VERSIONS OF JAX PLANNER
@@ -1058,6 +1054,7 @@ class JaxDeepReactivePolicy(JaxPlan):
 # - more stable but slower line search based planner
 #
 # ***********************************************************************
+
 
 class RollingMean:
     '''Maintains an estimate of the rolling mean of a stream of real-valued 
@@ -1080,7 +1077,7 @@ class RollingMean:
 class JaxPlannerPlot:
     '''Supports plotting and visualization of a JAX policy in real time.'''
     
-    def __init__(self, rddl: RDDLPlanningModel, horizon: int, 
+    def __init__(self, rddl: RDDLPlanningModel, horizon: int,
                  show_violin: bool=True, show_action: bool=True) -> None:
         '''Creates a new planner visualizer.
         
@@ -1128,7 +1125,7 @@ class JaxPlannerPlot:
                 for dim in rddl.object_counts(rddl.variable_params[name]):
                     action_dim *= dim     
                 action_plot = ax.pcolormesh(
-                    np.zeros((action_dim, horizon)), 
+                    np.zeros((action_dim, horizon)),
                     cmap='seismic', vmin=vmin, vmax=vmax)
                 ax.set_aspect('auto')        
                 ax.set_xlabel('decision epoch')
@@ -1404,7 +1401,7 @@ class JaxBackpropPlanner:
         
         # Jax compilation of the exact RDDL for testing
         self.test_compiled = JaxRDDLCompiler(
-            rddl=rddl, 
+            rddl=rddl,
             logger=self.logger,
             use64bit=self.use64bit)
         self.test_compiled.compile(log_jax_expr=True, heading='EXACT MODEL')
@@ -1547,7 +1544,7 @@ class JaxBackpropPlanner:
         return init_train, init_test
     
     def as_optimization_problem(
-            self, key: Optional[random.PRNGKey]=None, 
+            self, key: Optional[random.PRNGKey]=None,
             policy_hyperparams: Optional[Pytree]=None,
             loss_function_updates_key: bool=True,
             grad_function_updates_key: bool=False) -> Tuple[Callable, Callable, np.ndarray, Callable]:
@@ -1599,7 +1596,7 @@ class JaxBackpropPlanner:
         @jax.jit
         def _loss_with_key(key, params_1d):
             policy_params = unravel_fn(params_1d)
-            loss_val, _ = loss_fn(key, policy_params, policy_hyperparams, 
+            loss_val, _ = loss_fn(key, policy_params, policy_hyperparams,
                                   train_subs, model_params)
             return loss_val
         
@@ -1607,7 +1604,7 @@ class JaxBackpropPlanner:
         def _grad_with_key(key, params_1d):
             policy_params = unravel_fn(params_1d)
             grad_fn = jax.grad(loss_fn, argnums=1, has_aux=True)
-            grad_val, _ = grad_fn(key, policy_params, policy_hyperparams, 
+            grad_val, _ = grad_fn(key, policy_params, policy_hyperparams,
                                   train_subs, model_params)
             grad_1d = jax.flatten_util.ravel_pytree(grad_val)[0]
             return grad_1d
@@ -1947,7 +1944,7 @@ class JaxBackpropPlanner:
                   f'    best_grad_norm={grad_norm}\n'
                   f'    diagnosis: {diagnosis}\n')
     
-    def _perform_diagnosis(self, last_iter_improve, 
+    def _perform_diagnosis(self, last_iter_improve,
                            train_return, test_return, best_return, grad_norm):
         max_grad_norm = max(jax.tree_util.tree_leaves(grad_norm))
         grad_is_zero = np.allclose(max_grad_norm, 0)
@@ -2126,7 +2123,7 @@ class JaxLineSearchPlanner(JaxBackpropPlanner):
                 trials += 1
                 step *= decay
                 f_step, new_params, new_state = _jax_wrapped_line_search_trial(
-                    step, grad, key, policy_params, hyperparams, subs, 
+                    step, grad, key, policy_params, hyperparams, subs,
                     model_params, opt_state)
                 if f_step < best_f:
                     best_f, best_step, best_params, best_state = \
@@ -2139,7 +2136,6 @@ class JaxLineSearchPlanner(JaxBackpropPlanner):
             return best_params, True, best_state, opt_aux, best_f, log
             
         return _jax_wrapped_plan_update
-
 
 # ***********************************************************************
 # ALL VERSIONS OF RISK FUNCTIONS
@@ -2171,7 +2167,6 @@ def cvar_utility(returns: jnp.ndarray, alpha: float) -> float:
     alpha_mask = jax.lax.stop_gradient(
         returns <= jnp.percentile(returns, q=100 * alpha))
     return jnp.sum(returns * alpha_mask) / jnp.sum(alpha_mask)
-    
 
 # ***********************************************************************
 # ALL VERSIONS OF CONTROLLERS
@@ -2181,12 +2176,13 @@ def cvar_utility(returns: jnp.ndarray, alpha: float) -> float:
 #
 # ***********************************************************************
 
+
 class JaxOfflineController(BaseAgent):
     '''A container class for a Jax policy trained offline.'''
     
     use_tensor_obs = True
     
-    def __init__(self, planner: JaxBackpropPlanner, 
+    def __init__(self, planner: JaxBackpropPlanner,
                  key: Optional[random.PRNGKey]=None,
                  eval_hyperparams: Optional[Dict[str, Any]]=None,
                  params: Optional[Pytree]=None,
@@ -2241,7 +2237,7 @@ class JaxOnlineController(BaseAgent):
     
     use_tensor_obs = True
     
-    def __init__(self, planner: JaxBackpropPlanner, 
+    def __init__(self, planner: JaxBackpropPlanner,
                  key: Optional[random.PRNGKey]=None,
                  eval_hyperparams: Optional[Dict[str, Any]]=None,
                  warm_start: bool=True,

--- a/pyRDDLGym_jax/core/planner.py
+++ b/pyRDDLGym_jax/core/planner.py
@@ -103,10 +103,13 @@ def _load_config(config, args):
     compare_kwargs = model_args.get('comparison_kwargs', {})
     sampling_name = model_args.get('sampling', 'GumbelSoftmax')
     sampling_kwargs = model_args.get('sampling_kwargs', {})
+    rounding_name = model_args.get('rounding', 'SoftRounding')
+    rounding_kwargs = model_args.get('rounding_kwargs', {})
     logic_kwargs['tnorm'] = getattr(logic, tnorm_name)(**tnorm_kwargs)
     logic_kwargs['complement'] = getattr(logic, comp_name)(**comp_kwargs)
     logic_kwargs['comparison'] = getattr(logic, compare_name)(**compare_kwargs)
     logic_kwargs['sampling'] = getattr(logic, sampling_name)(**sampling_kwargs)
+    logic_kwargs['rounding'] = getattr(logic, rounding_name)(**rounding_kwargs)
     
     # read the policy settings
     plan_method = planner_args.pop('method')

--- a/pyRDDLGym_jax/core/planner.py
+++ b/pyRDDLGym_jax/core/planner.py
@@ -506,7 +506,7 @@ class JaxStraightLinePlan(JaxPlan):
         def _jax_bool_action_to_param(var, action, hyperparams):
             if wrap_sigmoid:
                 weight = hyperparams[var]
-                return (-1.0 / weight) * jnp.log(1.0 / action - 1.0)
+                return jax.scipy.special.logit(action) / weight
             else:
                 return action
             

--- a/pyRDDLGym_jax/examples/configs/Cartpole_Continuous_gym_replan.cfg
+++ b/pyRDDLGym_jax/examples/configs/Cartpole_Continuous_gym_replan.cfg
@@ -17,3 +17,4 @@ rollout_horizon=30
 key=42
 epochs=1000
 train_seconds=1
+print_summary=False

--- a/pyRDDLGym_jax/examples/configs/PowerGen_Continuous_replan.cfg
+++ b/pyRDDLGym_jax/examples/configs/PowerGen_Continuous_replan.cfg
@@ -17,3 +17,4 @@ rollout_horizon=5
 key=42
 epochs=2000
 train_seconds=1
+print_summary=False

--- a/pyRDDLGym_jax/examples/configs/Reservoir_Continuous_replan.cfg
+++ b/pyRDDLGym_jax/examples/configs/Reservoir_Continuous_replan.cfg
@@ -17,3 +17,4 @@ rollout_horizon=5
 key=42
 epochs=500
 train_seconds=1
+print_summary=False

--- a/pyRDDLGym_jax/examples/configs/Wildfire_MDP_ippc2014_replan.cfg
+++ b/pyRDDLGym_jax/examples/configs/Wildfire_MDP_ippc2014_replan.cfg
@@ -6,9 +6,9 @@ tnorm_kwargs={}
 
 [Optimizer]
 method='JaxStraightLinePlan'
-method_kwargs={'initializer': 'normal', 'initializer_kwargs': {'stddev': 0.001}}
+method_kwargs={}
 optimizer='rmsprop'
-optimizer_kwargs={'learning_rate': 0.001}
+optimizer_kwargs={'learning_rate': 0.1}
 batch_size_train=32
 batch_size_test=32
 rollout_horizon=5
@@ -18,3 +18,4 @@ key=42
 epochs=1000
 train_seconds=1
 policy_hyperparams={'cut-out': 10.0, 'put-out': 10.0}
+print_summary=False

--- a/pyRDDLGym_jax/examples/configs/default_replan.cfg
+++ b/pyRDDLGym_jax/examples/configs/default_replan.cfg
@@ -18,3 +18,4 @@ key=42
 epochs=2000
 train_seconds=1
 policy_hyperparams=2.0
+print_summary=False

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,6 @@ setup(
           'jax>=0.4.12',
           'optax>=0.1.9',
           'dm-haiku>=0.0.10',
-          # 'tensorflow>=2.13.0',
           'tensorflow-probability>=0.21.0'
         ],
       python_requires=">=3.8",


### PR DESCRIPTION
A variety of numerical stability and API fixes to the jax planner:
- added separate rounding logic in fuzzy logic API
- replaced some manual logic calculations and boolean action logits in planner with builtins for numerical stability
- more numerically stable bounding logic for wrap_non_bool setting
- updated configs