### PR TITLE
chore: added warmstart initialization for JaxPlan

### DIFF
--- a/pyRDDLGym_jax/core/planner.py
+++ b/pyRDDLGym_jax/core/planner.py
@@ -760,6 +760,8 @@ class JaxStraightLinePlan(JaxPlan):
             params = {}
             for (var, shape) in shapes.items():
                 if ranges[var] != 'bool' or not stack_bool_params: 
+                    key, subkey = random.split(key)
+                    
                     init_function = init
                     if var in initializer_per_action.keys():
                         init_function = initializer_per_action[var]

--- a/pyRDDLGym_jax/core/tuning.py
+++ b/pyRDDLGym_jax/core/tuning.py
@@ -363,7 +363,8 @@ def objective_slp(params, kwargs, key, index):
         policy_hyperparams=policy_hparams,
         print_summary=False,
         print_progress=False,
-        tqdm_position=index)
+        tqdm_position=index,
+        return_callback=False)
     
     # initialize env for evaluation (need fresh copy to avoid concurrency)
     env = RDDLEnv(domain=kwargs['domain'],


### PR DESCRIPTION
This PR modifies JaxPlan to allow it to start with predefined weights for both SLP and DRPs.

It used here: https://github.com/danielbdias/ptb-abstraction-experimentation/blob/main/experiments/intervalanalysis/step3_create_warm_start_policies_and_run.py#L65