### PR TITLE
Parameter-Exploring Policy Gradient Hybridization (Beta)

### DIFF
--- a/pyRDDLGym_jax/core/compiler.py
+++ b/pyRDDLGym_jax/core/compiler.py
@@ -1,3 +1,18 @@
+# ***********************************************************************
+# JAXPLAN
+# 
+# Author: Michael Gimelfarb
+#
+# REFERENCES:
+# 
+# [1] Gimelfarb, Michael, Ayal Taitler, and Scott Sanner. "JaxPlan and GurobiPlan: 
+# Optimization Baselines for Replanning in Discrete and Mixed Discrete-Continuous 
+# Probabilistic Domains." Proceedings of the International Conference on Automated 
+# Planning and Scheduling. Vol. 34. 2024.
+#
+# ***********************************************************************
+
+
 from functools import partial
 import traceback
 from typing import Any, Callable, Dict, List, Optional

--- a/pyRDDLGym_jax/core/logic.py
+++ b/pyRDDLGym_jax/core/logic.py
@@ -759,14 +759,14 @@ class FuzzyLogic(Logic):
     
     def __str__(self) -> str:
         return (f'model relaxation:\n'
-                f'    tnorm         ={str(self.tnorm)}\n'
-                f'    complement    ={str(self.complement)}\n'
-                f'    comparison    ={str(self.comparison)}\n'
-                f'    sampling      ={str(self.sampling)}\n'
-                f'    rounding      ={str(self.rounding)}\n'
-                f'    control       ={str(self.control)}\n'
-                f'    underflow_tol ={self.eps}\n'
-                f'    use_64_bit    ={self.use64bit}')
+                f'    tnorm        ={str(self.tnorm)}\n'
+                f'    complement   ={str(self.complement)}\n'
+                f'    comparison   ={str(self.comparison)}\n'
+                f'    sampling     ={str(self.sampling)}\n'
+                f'    rounding     ={str(self.rounding)}\n'
+                f'    control      ={str(self.control)}\n'
+                f'    underflow_tol={self.eps}\n'
+                f'    use_64_bit   ={self.use64bit}\n')
 
     def summarize_hyperparameters(self) -> None:
         print(self.__str__())

--- a/pyRDDLGym_jax/core/logic.py
+++ b/pyRDDLGym_jax/core/logic.py
@@ -1,4 +1,31 @@
-from typing import Optional, Set
+# ***********************************************************************
+# JAXPLAN
+# 
+# Author: Michael Gimelfarb
+#
+# REFERENCES:
+#
+# [1] Gimelfarb, Michael, Ayal Taitler, and Scott Sanner. "JaxPlan and GurobiPlan: 
+# Optimization Baselines for Replanning in Discrete and Mixed Discrete-Continuous 
+# Probabilistic Domains." Proceedings of the International Conference on Automated 
+# Planning and Scheduling. Vol. 34. 2024.
+#
+# [2] Petersen, Felix, Christian Borgelt, Hilde Kuehne, and Oliver Deussen. "Learning with 
+# algorithmic supervision via continuous relaxations." Advances in Neural Information 
+# Processing Systems 34 (2021): 16520-16531.
+#
+# [3] Agustsson, Eirikur, and Lucas Theis. "Universally quantized neural compression." 
+# Advances in neural information processing systems 33 (2020): 12367-12376.
+#
+# [4] Gupta, Madan M., and J11043360726 Qi. "Theory of T-norms and fuzzy inference 
+# methods." Fuzzy sets and systems 40, no. 3 (1991): 431-450.
+#
+# [5] Jang, Eric, Shixiang Gu, and Ben Poole. "Categorical Reparametrization with 
+# Gumble-Softmax." In International Conference on Learning Representations (ICLR 2017). 
+# OpenReview. net, 2017.
+#
+# ***********************************************************************
+
 
 import jax
 import jax.numpy as jnp

--- a/pyRDDLGym_jax/core/planner.py
+++ b/pyRDDLGym_jax/core/planner.py
@@ -1323,7 +1323,7 @@ class GaussianPGPE(PGPE):
                 subkey, params_neg, policy_hyperparams, subs, model_params)
             if scale_reward:
                 r_mu_scale = jnp.maximum(1e-5, r_max - (r_pos + r_neg) / 2)
-                r_sigma_scale = jnp.maximum(1e-5, r_max)
+                r_sigma_scale = jnp.maximum(1e-5, jnp.abs(r_max))
             else:
                 r_mu_scale = 1.0
                 r_sigma_scale = 1.0
@@ -2093,7 +2093,7 @@ r"""
             pgpe_improve = False
             if self.use_pgpe:
                 key, subkey = random.split(key)
-                r_max = abs(best_loss.item()) if it else 1.0
+                r_max = best_loss.item() if it else 1.0
                 pgpe_params, pgpe_opt_state, pgpe_param, pgpe_converged = \
                     self.pgpe.update(subkey, pgpe_params, policy_hyperparams, 
                                      test_subs, model_params, pgpe_opt_state, r_max)

--- a/pyRDDLGym_jax/core/planner.py
+++ b/pyRDDLGym_jax/core/planner.py
@@ -165,16 +165,18 @@ def _load_config(config, args):
             planner_args['optimizer'] = optimizer
 
     # pgpe optimizer
-    pgpe_optimizer = planner_args.get('optimizer_pgpe', None)
-    if pgpe_optimizer is not None:
-        optimizer = _getattr_any(packages=[optax], item=pgpe_optimizer)
-        if optimizer is None:
-            raise_warning(
-                f'Ignoring invalid optimizer <{pgpe_optimizer}>.', 'red')
-            del planner_args['optimizer_pgpe']
-        else:
-            planner_args['optimizer_pgpe'] = optimizer
-        
+    pgpe_method = planner_args.get('pgpe', 'GaussianPGPE')
+    pgpe_kwargs = planner_args.pop('pgpe_kwargs', {})
+    if pgpe_method is not None:
+        if 'optimizer' in pgpe_kwargs:
+            pgpe_optimizer = _getattr_any(packages=[optax], item=pgpe_kwargs['optimizer'])
+            if pgpe_optimizer is None:
+                raise_warning(f'Ignoring invalid optimizer <{pgpe_optimizer}>.', 'red')
+                del pgpe_kwargs['optimizer']
+            else:
+                pgpe_kwargs['optimizer'] = pgpe_optimizer
+        planner_args['pgpe'] = getattr(sys.modules[__name__], pgpe_method)(**pgpe_kwargs)
+
     # optimize call RNG key
     planner_key = train_args.get('key', None)
     if planner_key is not None:
@@ -480,16 +482,16 @@ class JaxStraightLinePlan(JaxPlan):
         bounds = '\n        '.join(
             map(lambda kv: f'{kv[0]}: {kv[1]}', self.bounds.items()))
         return (f'policy hyper-parameters:\n'
-                f'    initializer          ={self._initializer_base}\n'
-                f'constraint-sat strategy (simple):\n'
-                f'    parsed_action_bounds =\n        {bounds}\n'
-                f'    wrap_sigmoid         ={self._wrap_sigmoid}\n'
-                f'    wrap_sigmoid_min_prob={self._min_action_prob}\n'
-                f'    wrap_non_bool        ={self._wrap_non_bool}\n'
-                f'constraint-sat strategy (complex):\n'
-                f'    wrap_softmax         ={self._wrap_softmax}\n'
-                f'    use_new_projection   ={self._use_new_projection}\n'
-                f'    max_projection_iters ={self._max_constraint_iter}')
+                f'    initializer={self._initializer_base}\n'
+                f'    constraint-sat strategy (simple):\n'
+                f'        parsed_action_bounds =\n        {bounds}\n'
+                f'        wrap_sigmoid         ={self._wrap_sigmoid}\n'
+                f'        wrap_sigmoid_min_prob={self._min_action_prob}\n'
+                f'        wrap_non_bool        ={self._wrap_non_bool}\n'
+                f'    constraint-sat strategy (complex):\n'
+                f'        wrap_softmax        ={self._wrap_softmax}\n'
+                f'        use_new_projection  ={self._use_new_projection}\n'
+                f'        max_projection_iters={self._max_constraint_iter}\n')
     
     def compile(self, compiled: JaxRDDLCompilerWithGrad,
                 _bounds: Bounds,
@@ -867,15 +869,16 @@ class JaxDeepReactivePolicy(JaxPlan):
         bounds = '\n        '.join(
             map(lambda kv: f'{kv[0]}: {kv[1]}', self.bounds.items()))
         return (f'policy hyper-parameters:\n'
-                f'    topology            ={self._topology}\n'
-                f'    activation_fn       ={self._activations[0].__name__}\n'
-                f'    initializer         ={type(self._initializer_base).__name__}\n'
-                f'    apply_input_norm    ={self._normalize}\n'
-                f'    input_norm_layerwise={self._normalize_per_layer}\n'
-                f'    input_norm_args     ={self._normalizer_kwargs}\n'
-                f'constraint-sat strategy:\n'
-                f'    parsed_action_bounds=\n        {bounds}\n'
-                f'    wrap_non_bool       ={self._wrap_non_bool}')
+                f'    topology     ={self._topology}\n'
+                f'    activation_fn={self._activations[0].__name__}\n'
+                f'    initializer  ={type(self._initializer_base).__name__}\n'
+                f'    input norm:\n'
+                f'        apply_input_norm    ={self._normalize}\n'
+                f'        input_norm_layerwise={self._normalize_per_layer}\n'
+                f'        input_norm_args     ={self._normalizer_kwargs}\n'
+                f'    constraint-sat strategy:\n'
+                f'        parsed_action_bounds=\n        {bounds}\n'
+                f'        wrap_non_bool       ={self._wrap_non_bool}\n')
         
     def compile(self, compiled: JaxRDDLCompilerWithGrad,
                 _bounds: Bounds,
@@ -1101,10 +1104,11 @@ class JaxDeepReactivePolicy(JaxPlan):
     
     
 # ***********************************************************************
-# ALL VERSIONS OF JAX PLANNER
+# SUPPORTING FUNCTIONS
 # 
-# - simple gradient descent based planner
-# - more stable but slower line search based planner
+# - smoothed mean calculation
+# - planner status
+# - stopping criteria
 #
 # ***********************************************************************
 
@@ -1178,6 +1182,189 @@ class NoImprovementStoppingRule(JaxPlannerStoppingRule):
         return f'No improvement for {self.patience} iterations'
         
 
+# ***********************************************************************
+# PARAMETER EXPLORING POLICY GRADIENTS (PGPE)
+# 
+# - simple Gaussian PGPE
+#
+# ***********************************************************************
+
+
+class PGPE:
+    """Base class for all PGPE strategies."""
+
+    def __init__(self) -> None:
+        self._initializer = None
+        self._update = None
+
+    @property
+    def initialize(self):
+        return self._initializer
+
+    @property
+    def update(self):
+        return self._update
+
+    def compile(self, return_fn: Callable, rollout_fn: Callable, 
+                projection: Callable) -> None:
+        raise NotImplementedError
+
+
+class GaussianPGPE(PGPE):
+    """PGPE with a Gaussian parameter distribution."""
+
+    def __init__(self, batch_size: int=1, 
+                 init_sigma: float=1.0,
+                 min_sigma: float=1e-6,
+                 scale_reward: bool=True,
+                 optimizer: Callable[..., optax.GradientTransformation]=optax.adam,
+                 optimizer_kwargs_mu: Optional[Kwargs]=None,
+                 optimizer_kwargs_sigma: Optional[Kwargs]=None) -> None:
+        super().__init__()
+
+        self.batch_size = batch_size
+        self.init_sigma = init_sigma
+        self.min_sigma = min_sigma
+        self.scale_reward = scale_reward
+        
+        # set optimizers
+        if optimizer_kwargs_mu is None:
+            optimizer_kwargs_mu = {'learning_rate': 0.1}
+        self.optimizer_kwargs_mu = optimizer_kwargs_mu
+        if optimizer_kwargs_sigma is None:
+            optimizer_kwargs_sigma = {'learning_rate': 0.1}
+        self.optimizer_kwargs_sigma = optimizer_kwargs_sigma
+        self.optimizer_name = optimizer
+        mu_optimizer = optimizer(**optimizer_kwargs_mu)
+        sigma_optimizer = optimizer(**optimizer_kwargs_sigma)
+        self.optimizers = (mu_optimizer, sigma_optimizer)
+    
+    def __str__(self) -> str:
+        return (f'PGPE hyper-parameters:\n'
+                f'    method      ={self.__class__.__name__}\n'
+                f'    batch_size  ={self.batch_size}\n'
+                f'    init_sigma  ={self.init_sigma}\n'
+                f'    min_sigma   ={self.min_sigma}\n'
+                f'    scale_reward={self.scale_reward}\n'
+                f'    optimizer   ={self.optimizer_name}\n'
+                f'    optimizer_kwargs:\n'
+                f'        mu   ={self.optimizer_kwargs_mu}\n'
+                f'        sigma={self.optimizer_kwargs_sigma}\n'
+        )
+
+    def compile(self, return_fn: Callable, rollout_fn: Callable, 
+                projection: Callable) -> None:
+        sigma0 = self.init_sigma
+        min_sigma = self.min_sigma
+        scale_reward = self.scale_reward
+        batch_size = self.batch_size
+        optimizers = (mu_optimizer, sigma_optimizer) = self.optimizers
+
+        # initializer
+        def _jax_wrapped_pgpe_init(key, policy_params):
+            mu = policy_params
+            sigma = jax.tree_map(lambda x: sigma0 * jnp.ones_like(x), mu)
+            pgpe_params = (mu, sigma)
+            pgpe_opt_state = tuple(opt.init(param) 
+                                   for (opt, param) in zip(optimizers, pgpe_params))
+            return pgpe_params, pgpe_opt_state
+        
+        self._initializer = jax.jit(_jax_wrapped_pgpe_init)
+
+        # parameter sampling functions
+        def _jax_wrapped_mu_noise(key, sigma):
+            return sigma * random.normal(key, shape=jnp.shape(sigma))
+
+        def _jax_wrapped_sample_params(key, mu, sigma):
+            keys = random.split(key, num=len(jax.tree_util.tree_leaves(mu)))
+            keys_pytree = jax.tree_util.tree_unflatten(
+                treedef=jax.tree_util.tree_structure(mu), leaves=keys)
+            epsilon = jax.tree_map(_jax_wrapped_mu_noise, keys_pytree, sigma)     
+            params_pos = jax.tree_map(jnp.add, mu, epsilon)
+            params_neg = jax.tree_map(jnp.subtract, mu, epsilon)
+            return params_pos, params_neg
+        
+        def _jax_wrapped_sample_params_batched(key, mu, sigma):
+            keys = random.split(key, num=batch_size)
+            batched_params = jax.vmap(
+                _jax_wrapped_sample_params, in_axes=(0, None, None))(keys, mu, sigma)
+            return batched_params
+        
+        # evaluation functions
+        def _jax_wrapped_return(key, policy_params, policy_hyperparams, subs, model_params):
+            log, _ = rollout_fn(
+                key, policy_params, policy_hyperparams, subs, model_params)
+            mean_return = jnp.mean(return_fn(log['reward']))
+            return mean_return
+        
+        def _jax_wrapped_return_batched(key, batched_params, policy_hyperparams,
+                                        subs, model_params):
+            keys = random.split(key, num=batch_size)
+            batched_returns = jax.vmap(
+                _jax_wrapped_return, in_axes=(0, 0, None, None, None)
+            )(keys, batched_params, policy_hyperparams, subs, model_params)
+            return batched_returns
+        
+        # policy gradient update functions
+        def _jax_wrapped_mu_grad(params, mu, sigma, r):
+            return jax.tree_map(lambda p, m, s: -(p - m) * r, params, mu, sigma)
+        
+        def _jax_wrapped_sigma_grad(params, mu, sigma, r):
+            return jax.tree_map(
+                lambda p, m, s: -(jnp.square(p - m) / s - s) * r, params, mu, sigma)
+            
+        def _jax_wrapped_pgpe_grad(key, mu, sigma, policy_hyperparams, subs, model_params,
+                                   r_max):
+            key, subkey = random.split(key)
+            params_pos, params_neg = _jax_wrapped_sample_params_batched(key, mu, sigma)
+            r_pos = _jax_wrapped_return_batched(
+                subkey, params_pos, policy_hyperparams, subs, model_params)
+            r_neg = _jax_wrapped_return_batched(
+                subkey, params_neg, policy_hyperparams, subs, model_params)
+            if scale_reward:
+                r_mu_scale = jnp.maximum(1e-5, r_max - (r_pos + r_neg) / 2)
+                r_sigma_scale = jnp.maximum(1e-5, r_max)
+            else:
+                r_mu_scale = 1.0
+                r_sigma_scale = 1.0
+            r_mu = (r_pos - r_neg) / (2 * r_mu_scale)
+            r_sigma = (r_pos + r_neg) / (2 * r_sigma_scale)
+            mu_grads = jax.vmap(_jax_wrapped_mu_grad, in_axes=(0, None, None, 0))(
+                params_pos, mu, sigma, r_mu)
+            sigma_grads = jax.vmap(_jax_wrapped_sigma_grad, in_axes=(0, None, None, 0))(
+                params_pos, mu, sigma, r_sigma)
+            grad = jax.tree_map(lambda g: jnp.mean(g, axis=0), (mu_grads, sigma_grads))
+            return grad
+
+        def _jax_wrapped_policy_gradient_update(key, pgpe_params, policy_hyperparams, 
+                                                subs, model_params, pgpe_opt_state, r_max):
+            mu, sigma = pgpe_params
+            mu_state, sigma_state = pgpe_opt_state
+            mu_grad, sigma_grad = _jax_wrapped_pgpe_grad(
+                key, mu, sigma, policy_hyperparams, subs, model_params, r_max)
+            mu_updates, new_mu_state = mu_optimizer.update(mu_grad, mu_state, params=mu) 
+            sigma_updates, new_sigma_state = sigma_optimizer.update(
+                sigma_grad, sigma_state, params=sigma) 
+            new_mu = optax.apply_updates(mu, mu_updates)
+            new_mu, converged = projection(new_mu, policy_hyperparams)
+            new_sigma = optax.apply_updates(sigma, sigma_updates)
+            new_sigma = jax.tree_map(lambda x: jnp.maximum(x, min_sigma), new_sigma)
+            new_pgpe_params = (new_mu, new_sigma)
+            new_pgpe_opt_state = (new_mu_state, new_sigma_state)
+            policy_params = new_mu
+            return new_pgpe_params, new_pgpe_opt_state, policy_params, converged
+
+        self._update = jax.jit(_jax_wrapped_policy_gradient_update)
+
+
+# ***********************************************************************
+# ALL VERSIONS OF JAX PLANNER
+# 
+# - simple gradient descent based planner
+# 
+# ***********************************************************************
+
+
 class JaxBackpropPlanner:
     '''A class for optimizing an action sequence in the given RDDL MDP using 
     gradient descent.'''
@@ -1194,18 +1381,11 @@ class JaxBackpropPlanner:
                  clip_grad: Optional[float]=None,
                  line_search_kwargs: Optional[Kwargs]=None,
                  noise_kwargs: Optional[Kwargs]=None,
+                 pgpe: Optional[PGPE]=GaussianPGPE(),
                  logic: Logic=FuzzyLogic(),
                  use_symlog_reward: bool=False,
                  utility: Union[Callable[[jnp.ndarray], float], str]='mean',
                  utility_kwargs: Optional[Kwargs]=None,
-                 use_pgpe: bool=True,
-                 batch_size_pgpe: int=1,
-                 min_sigma_pgpe: float=1e-6,
-                 init_sigma_pgpe: float=1.0,
-                 scale_reward_pgpe: bool=True,
-                 optimizer_pgpe: Callable[..., optax.GradientTransformation]=optax.adam,
-                 optimizer_kwargs_pgpe_mu: Optional[Kwargs]=None,
-                 optimizer_kwargs_pgpe_sigma: Optional[Kwargs]=None,
                  cpfs_without_grad: Optional[Set[str]]=None,
                  compile_non_fluent_exact: bool=True,
                  logger: Optional[Logger]=None,
@@ -1232,6 +1412,7 @@ class JaxBackpropPlanner:
         :param line_search_kwargs: parameters to pass to optional line search
         method to scale learning rate
         :param noise_kwargs: parameters of optional gradient noise
+        :param pgpe: optional policy gradient to run alongside the planner
         :param logic: a subclass of Logic for mapping exact mathematical
         operations to their differentiable counterparts 
         :param use_symlog_reward: whether to use the symlog transform on the 
@@ -1270,19 +1451,9 @@ class JaxBackpropPlanner:
         self.clip_grad = clip_grad
         self.line_search_kwargs = line_search_kwargs
         self.noise_kwargs = noise_kwargs
+        self.pgpe = pgpe
+        self.use_pgpe = pgpe is not None
         
-        self.use_pgpe = use_pgpe
-        self.batch_size_pgpe = batch_size_pgpe
-        self.pgpe_min_sigma = min_sigma_pgpe
-        self.pgpe_init_sigma = init_sigma_pgpe
-        self.scale_reward_pgpe = scale_reward_pgpe
-        if optimizer_kwargs_pgpe_mu is None:
-            optimizer_kwargs_pgpe_mu = {'learning_rate': 0.1}
-        self.optimizer_kwargs_pgpe_mu = optimizer_kwargs_pgpe_mu
-        if optimizer_kwargs_pgpe_sigma is None:
-            optimizer_kwargs_pgpe_sigma = {'learning_rate': 0.1}
-        self.optimizer_kwargs_pgpe_sigma = optimizer_kwargs_pgpe_sigma
-
         # set optimizer
         try:
             optimizer = optax.inject_hyperparams(optimizer)(**optimizer_kwargs)
@@ -1304,15 +1475,6 @@ class JaxBackpropPlanner:
             pipeline.append(optax.scale_by_zoom_linesearch(**line_search_kwargs))
         self.optimizer = optax.chain(*pipeline)
         
-        # optimizer for PGPE
-        self.pgpe_optimizer_name = optimizer_pgpe
-        if self.use_pgpe:
-            self.mu_optimizer = optimizer_pgpe(**optimizer_kwargs_pgpe_mu)
-            self.sigma_optimizer = optimizer_pgpe(**optimizer_kwargs_pgpe_sigma)
-        else:
-            self.mu_optimizer = None
-            self.sigma_optimizer = None
-
         # set utility
         if isinstance(utility, str):
             utility = utility.lower()
@@ -1348,7 +1510,6 @@ class JaxBackpropPlanner:
         
         self._jax_compile_rddl()        
         self._jax_compile_optimizer()
-        self._jax_compile_pgpe_optimizer()
     
     def summarize_system(self) -> str:
         try:
@@ -1389,39 +1550,32 @@ r"""
                   f'    non_fluents exact ={self.compile_non_fluent_exact}\n'
                   f'    cpfs_no_gradient  ={self.cpfs_without_grad}\n'
                   f'optimizer hyper-parameters:\n'
-                  f'    use_64_bit                 ={self.use64bit}\n'
-                  f'    optimizer                  ={self.optimizer_name}\n'
-                  f'    optimizer args             ={self.optimizer_kwargs}\n'
-                  f'    optimizer (pgpe)           ={self.pgpe_optimizer_name}\n'
-                  f'    optimizer args mu (pgpe)   ={self.optimizer_kwargs_pgpe_mu}\n'
-                  f'    optimizer args sigma (pgpe)={self.optimizer_kwargs_pgpe_sigma}\n'
-                  f'    clip_gradient              ={self.clip_grad}\n'
-                  f'    line_search_kwargs         ={self.line_search_kwargs}\n'
-                  f'    noise_kwargs               ={self.noise_kwargs}\n'
-                  f'    batch_size_train           ={self.batch_size_train}\n'
-                  f'    batch_size_test            ={self.batch_size_test}\n'
-                  f'    batch_size (pgpe)          ={self.batch_size_pgpe}\n'
-                  f'    use_pgpe                   ={self.use_pgpe}\n'
-                  f'    initial sigma (pgpe)       ={self.pgpe_init_sigma}\n'
-                  f'    minimum sigma (pgpe)       ={self.pgpe_min_sigma}\n'
-                  f'    scale_reward (pgpe)        ={self.scale_reward_pgpe}')
-        result += '\n' + str(self.plan)
-        result += '\n' + str(self.logic)
+                  f'    use_64_bit        ={self.use64bit}\n'
+                  f'    optimizer         ={self.optimizer_name}\n'
+                  f'    optimizer args    ={self.optimizer_kwargs}\n'
+                  f'    clip_gradient     ={self.clip_grad}\n'
+                  f'    line_search_kwargs={self.line_search_kwargs}\n'
+                  f'    noise_kwargs      ={self.noise_kwargs}\n'
+                  f'    batch_size_train  ={self.batch_size_train}\n'
+                  f'    batch_size_test   ={self.batch_size_test}\n')
+        result += str(self.plan)
+        if self.use_pgpe:
+            result += str(self.pgpe)
+        result += str(self.logic)
         
         # print model relaxation information
-        if not self.compiled.model_params:
-            return result
-        result += '\n' + ('Some RDDL operations are non-differentiable '
-                          'and will be approximated as follows:' + '\n')
-        exprs_by_rddl_op, values_by_rddl_op = {}, {}
-        for info in self.compiled.model_parameter_info().values():
-            rddl_op = info['rddl_op']
-            exprs_by_rddl_op.setdefault(rddl_op, []).append(info['id'])
-            values_by_rddl_op.setdefault(rddl_op, []).append(info['init_value'])
-        for rddl_op in sorted(exprs_by_rddl_op.keys()):
-            result += (f'    {rddl_op}:\n'
-                       f'        addresses  ={exprs_by_rddl_op[rddl_op]}\n'
-                       f'        init_values={values_by_rddl_op[rddl_op]}\n')
+        if self.compiled.model_params:
+            result += ('Some RDDL operations are non-differentiable '
+                       'and will be approximated as follows:' + '\n')
+            exprs_by_rddl_op, values_by_rddl_op = {}, {}
+            for info in self.compiled.model_parameter_info().values():
+                rddl_op = info['rddl_op']
+                exprs_by_rddl_op.setdefault(rddl_op, []).append(info['id'])
+                values_by_rddl_op.setdefault(rddl_op, []).append(info['init_value'])
+            for rddl_op in sorted(exprs_by_rddl_op.keys()):
+                result += (f'    {rddl_op}:\n'
+                           f'        addresses  ={exprs_by_rddl_op[rddl_op]}\n'
+                           f'        init_values={values_by_rddl_op[rddl_op]}\n')
         return result
         
     def summarize_hyperparameters(self) -> None:
@@ -1487,6 +1641,11 @@ r"""
         # optimization
         self.update = self._jax_update(train_loss)
         self.check_zero_grad = self._jax_check_zero_gradients()
+
+        # pgpe option
+        if self.use_pgpe:
+            test_return_fn = self._jax_return(use_symlog=False)
+            self.pgpe.compile(test_return_fn, test_rollouts, self.plan.projection)
     
     def _jax_return(self, use_symlog):
         gamma = self.rddl.discount
@@ -1695,116 +1854,7 @@ r"""
             return grad
         
         return _loss_function, _grad_function, guess_1d, jax.jit(unravel_fn)
-        
-    # ===========================================================================
-    # COMPILATION SUBROUTINES - PGPE
-    # ===========================================================================
-
-    def _jax_compile_pgpe_optimizer(self):
-        if self.use_pgpe:
-            self.pgpe_init = jax.jit(self._jax_pgpe_init())
-            self.pgpe_update = jax.jit(
-                self._jax_pgpe_update(self.batch_size_pgpe, self.test_rollouts))
-        else:
-            self.pgpe_init, self.pgpe_update = None, None
-
-    def _jax_pgpe_init(self):
-        mu_optimizer = self.mu_optimizer
-        sigma_optimizer = self.sigma_optimizer
-
-        def _jax_wrapped_init(key, mu0, sigma0):
-            sigma = jax.tree_map(lambda x: sigma0 * jnp.ones_like(x), mu0)
-            mu_state = mu_optimizer.init(mu0)
-            sigma_state = sigma_optimizer.init(sigma)
-            return mu0, sigma, mu_state, sigma_state
-        
-        return _jax_wrapped_init
-
-    def _jax_pgpe_update(self, batch_size, rollout_fn):
-        projection = self.plan.projection
-        return_fn = self._jax_return(use_symlog=False)
-        min_sigma = self.pgpe_min_sigma
-        scale_reward = self.scale_reward_pgpe
-        mu_optimizer = self.mu_optimizer
-        sigma_optimizer = self.sigma_optimizer
-
-        def _jax_wrapped_mu_noise(key, sigma):
-            return sigma * random.normal(key, shape=jnp.shape(sigma))
-
-        def _jax_wrapped_sample_params(key, mu, sigma):
-            keys = random.split(key, num=len(jax.tree_util.tree_leaves(mu)))
-            keys_pytree = jax.tree_util.tree_unflatten(
-                treedef=jax.tree_util.tree_structure(mu), leaves=keys)
-            epsilon = jax.tree_map(_jax_wrapped_mu_noise, keys_pytree, sigma)     
-            params_pos = jax.tree_map(jnp.add, mu, epsilon)
-            params_neg = jax.tree_map(jnp.subtract, mu, epsilon)
-            return params_pos, params_neg
-        
-        def _jax_wrapped_sample_params_batched(key, mu, sigma):
-            keys = random.split(key, num=batch_size)
-            batched_params = jax.vmap(
-                _jax_wrapped_sample_params, in_axes=(0, None, None))(keys, mu, sigma)
-            return batched_params
-        
-        def _jax_wrapped_return(key, policy_params, policy_hyperparams, subs, model_params):
-            log, _ = rollout_fn(
-                key, policy_params, policy_hyperparams, subs, model_params)
-            mean_return = jnp.mean(return_fn(log['reward']))
-            return mean_return
-        
-        def _jax_wrapped_return_batched(key, batched_params, policy_hyperparams,
-                                        subs, model_params):
-            keys = random.split(key, num=batch_size)
-            batched_returns = jax.vmap(
-                _jax_wrapped_return, in_axes=(0, 0, None, None, None)
-            )(keys, batched_params, policy_hyperparams, subs, model_params)
-            return batched_returns
-        
-        def _jax_wrapped_mu_grad(params, mu, sigma, r):
-            return jax.tree_map(lambda p, m, s: -(p - m) * r, params, mu, sigma)
-        
-        def _jax_wrapped_sigma_grad(params, mu, sigma, r):
-            return jax.tree_map(
-                lambda p, m, s: -(jnp.square(p - m) / s - s) * r, params, mu, sigma)
-            
-        def _jax_wrapped_pgpe_grad(key, mu, sigma, policy_hyperparams, subs, model_params,
-                                   r_max):
-            key, subkey = random.split(key)
-            params_pos, params_neg = _jax_wrapped_sample_params_batched(key, mu, sigma)
-            r_pos = _jax_wrapped_return_batched(
-                subkey, params_pos, policy_hyperparams, subs, model_params)
-            r_neg = _jax_wrapped_return_batched(
-                subkey, params_neg, policy_hyperparams, subs, model_params)
-            if scale_reward:
-                r_mu_scale = jnp.maximum(1e-4, r_max - (r_pos + r_neg) / 2)
-                r_sigma_scale = jnp.maximum(1e-4, r_max)
-            else:
-                r_mu_scale = 1.0
-                r_sigma_scale = 1.0
-            r_mu = (r_pos - r_neg) / (2 * r_mu_scale)
-            r_sigma = (r_pos + r_neg) / (2 * r_sigma_scale)
-            mu_grads = jax.vmap(_jax_wrapped_mu_grad, in_axes=(0, None, None, 0))(
-                params_pos, mu, sigma, r_mu)
-            sigma_grads = jax.vmap(_jax_wrapped_sigma_grad, in_axes=(0, None, None, 0))(
-                params_pos, mu, sigma, r_sigma)
-            grad = jax.tree_map(lambda g: jnp.mean(g, axis=0), (mu_grads, sigma_grads))
-            return grad
-
-        def _jax_wrapped_policy_gradient_update(key, mu, sigma, policy_hyperparams, subs, 
-                                                model_params, mu_state, sigma_state, r_max):
-            mu_grad, sigma_grad = _jax_wrapped_pgpe_grad(
-                key, mu, sigma, policy_hyperparams, subs, model_params, r_max)
-            mu_updates, new_mu_state = mu_optimizer.update(mu_grad, mu_state, params=mu) 
-            sigma_updates, new_sigma_state = sigma_optimizer.update(
-                sigma_grad, sigma_state, params=sigma) 
-            new_mu = optax.apply_updates(mu, mu_updates)
-            new_sigma = optax.apply_updates(sigma, sigma_updates)
-            new_sigma = jax.tree_map(lambda x: jnp.maximum(x, min_sigma), new_sigma)
-            new_mu, converged = projection(new_mu, policy_hyperparams)
-            return new_mu, new_sigma, new_mu_state, new_sigma_state, converged
-
-        return _jax_wrapped_policy_gradient_update
-        
+                
     # ===========================================================================
     # OPTIMIZE API
     # ===========================================================================
@@ -1980,11 +2030,10 @@ r"""
         
         # initialize pgpe parameters
         if self.use_pgpe:
-            pgpe_mu, pgpe_sigma, pgpe_mu_state, pgpe_sigma_state = self.pgpe_init(
-                key, policy_params, self.pgpe_init_sigma)
+            pgpe_params, pgpe_opt_state = self.pgpe.initialize(key, policy_params)
             rolling_pgpe_loss = RollingMean(test_rolling_window)
         else:
-            pgpe_mu, pgpe_sigma, pgpe_mu_state, pgpe_sigma_state = None, None, None, None
+            pgpe_params, pgpe_opt_state = None, None
             rolling_pgpe_loss = None
         total_pgpe_it = 0
 
@@ -2040,18 +2089,17 @@ r"""
             if self.use_pgpe:
                 key, subkey = random.split(key)
                 r_max = abs(best_loss.item()) if it else 1.0
-                pgpe_mu, pgpe_sigma, pgpe_mu_state, pgpe_sigma_state, pgpe_converged = \
-                    self.pgpe_update(subkey, pgpe_mu, pgpe_sigma, policy_hyperparams, 
-                                     test_subs, model_params, 
-                                     pgpe_mu_state, pgpe_sigma_state, r_max)
+                pgpe_params, pgpe_opt_state, pgpe_param, pgpe_converged = \
+                    self.pgpe.update(subkey, pgpe_params, policy_hyperparams, 
+                                     test_subs, model_params, pgpe_opt_state, r_max)
                 pgpe_loss, _ = self.test_loss(
-                    subkey, pgpe_mu, policy_hyperparams, test_subs, model_params_test)
+                    subkey, pgpe_param, policy_hyperparams, test_subs, model_params_test)
                 pgpe_loss_smooth = rolling_pgpe_loss.update(pgpe_loss)
                 pgpe_return = -pgpe_loss_smooth
 
                 # replace with PGPE if it reaches a new minimum or train loss invalid
                 if pgpe_loss_smooth < best_loss or not np.isfinite(train_loss):
-                    policy_params = pgpe_mu
+                    policy_params = pgpe_param
                     test_loss, test_loss_smooth = pgpe_loss, pgpe_loss_smooth
                     converged = pgpe_converged
                     pgpe_improve = True
@@ -2108,6 +2156,7 @@ r"""
                 'pgpe_return': pgpe_return,
                 'params': policy_params,
                 'best_params': best_params,
+                'pgpe_params': pgpe_params,
                 'last_iteration_improved': last_iter_improve,
                 'pgpe_improved': pgpe_improve,
                 'grad': train_log['grad'],

--- a/pyRDDLGym_jax/core/planner.py
+++ b/pyRDDLGym_jax/core/planner.py
@@ -1,3 +1,33 @@
+# ***********************************************************************
+# JAXPLAN
+# 
+# Author: Michael Gimelfarb
+#
+# RELEVANT SOURCES:
+#
+# [1] Gimelfarb, Michael, Ayal Taitler, and Scott Sanner. "JaxPlan and GurobiPlan: 
+# Optimization Baselines for Replanning in Discrete and Mixed Discrete-Continuous 
+# Probabilistic Domains." Proceedings of the International Conference on Automated 
+# Planning and Scheduling. Vol. 34. 2024.
+# 
+# [2] Patton, Noah, Jihwan Jeong, Mike Gimelfarb, and Scott Sanner. "A Distributional 
+# Framework for Risk-Sensitive End-to-End Planning in Continuous MDPs." In Proceedings of 
+# the AAAI Conference on Artificial Intelligence, vol. 36, no. 9, pp. 9894-9901. 2022.
+#
+# [3] Bueno, Thiago P., Leliane N. de Barros, Denis D. Mauá, and Scott Sanner. "Deep 
+# reactive policies for planning in stochastic nonlinear domains." In Proceedings of the 
+# AAAI Conference on Artificial Intelligence, vol. 33, no. 01, pp. 7530-7537. 2019.
+#
+# [4] Wu, Ga, Buser Say, and Scott Sanner. "Scalable planning with tensorflow for hybrid 
+# nonlinear domains." Advances in Neural Information Processing Systems 30 (2017).
+#
+# [5] Sehnke, Frank, and Tingting Zhao. "Baseline-free sampling in parameter exploring 
+# policy gradients: Super symmetric pgpe." Artificial Neural Networks: Methods and 
+# Applications in Bio-/Neuroinformatics. Springer International Publishing, 2015.
+#
+# ***********************************************************************
+
+
 from ast import literal_eval
 from collections import deque
 import configparser

--- a/pyRDDLGym_jax/core/simulator.py
+++ b/pyRDDLGym_jax/core/simulator.py
@@ -1,3 +1,23 @@
+# ***********************************************************************
+# JAXPLAN
+# 
+# Author: Michael Gimelfarb
+#
+# REFERENCES:
+# 
+# [1] Gimelfarb, Michael, Ayal Taitler, and Scott Sanner. "JaxPlan and GurobiPlan: 
+# Optimization Baselines for Replanning in Discrete and Mixed Discrete-Continuous 
+# Probabilistic Domains." Proceedings of the International Conference on Automated 
+# Planning and Scheduling. Vol. 34. 2024.
+# 
+# [2] Taitler, Ayal, Michael Gimelfarb, Jihwan Jeong, Sriram Gopalakrishnan, Martin 
+# Mladenov, Xiaotian Liu, and Scott Sanner. "pyRDDLGym: From RDDL to Gym Environments." 
+# In PRL Workshop Series {\textendash} Bridging the Gap Between AI Planning and 
+# Reinforcement Learning.
+#
+# ***********************************************************************
+
+
 import time
 from typing import Dict, Optional
 

--- a/pyRDDLGym_jax/core/tuning.py
+++ b/pyRDDLGym_jax/core/tuning.py
@@ -1,3 +1,18 @@
+# ***********************************************************************
+# JAXPLAN
+# 
+# Author: Michael Gimelfarb
+#
+# REFERENCES:
+# 
+# [1] Gimelfarb, Michael, Ayal Taitler, and Scott Sanner. "JaxPlan and GurobiPlan: 
+# Optimization Baselines for Replanning in Discrete and Mixed Discrete-Continuous 
+# Probabilistic Domains." Proceedings of the International Conference on Automated 
+# Planning and Scheduling. Vol. 34. 2024.
+#
+# ***********************************************************************
+
+
 import csv
 import datetime
 import threading

--- a/pyRDDLGym_jax/core/visualization.py
+++ b/pyRDDLGym_jax/core/visualization.py
@@ -1,3 +1,18 @@
+# ***********************************************************************
+# JAXPLAN
+# 
+# Author: Michael Gimelfarb
+#
+# REFERENCES:
+# 
+# [1] Gimelfarb, Michael, Ayal Taitler, and Scott Sanner. "JaxPlan and GurobiPlan: 
+# Optimization Baselines for Replanning in Discrete and Mixed Discrete-Continuous 
+# Probabilistic Domains." Proceedings of the International Conference on Automated 
+# Planning and Scheduling. Vol. 34. 2024.
+#
+# ***********************************************************************
+
+
 import ast
 import os
 from datetime import datetime


### PR DESCRIPTION
Implemented hybridization of vanilla JaxPlan (v1.2) with parameter-exploring policy gradients (PGPE). PGPE was chosen because it is general and does not make strong assumptions about the policy class, nor continuity of state nor action spaces. The hybridization ensures that if JaxPlan struggles on a particular problem due to discreteness or poor model relaxations, then PGPE provides an unbiased fallback to guide JaxPlan in determinization of optimal policy parameters.